### PR TITLE
fix(dkim): handle key regeneration failure and avoid redundant rspamd restarts

### DIFF
--- a/core/internal/service/domains/domains.go
+++ b/core/internal/service/domains/domains.go
@@ -523,6 +523,54 @@ func GetDKIMShortRecord(domain string, validateImmediate bool) (record v1.DNSRec
 	return getDKIMRecordWithKeySize(domain, "short", 1024, validateImmediate)
 }
 
+// ensureDKIMKeyPair generates the DKIM key pair for a domain/selector when either the private
+// or the public key file is missing. It touches key files only: the caller owns the signing
+// configuration and any rspamd reload, so a caller that rebuilds the whole config afterwards
+// does not pay for a per-key config rewrite and container restart.
+func ensureDKIMKeyPair(ctx context.Context, domain, selector string, keySize int) error {
+	dkimPath := public.AbsPath(filepath.Join(consts.RSPAMD_LIB_PATH, "dkim", domain))
+
+	if !public.IsDir(dkimPath) {
+		_ = os.MkdirAll(dkimPath, 0755)
+	}
+
+	dkimPriPath := filepath.Join(dkimPath, selector+".private")
+	dkimPubPath := filepath.Join(dkimPath, selector+".pub")
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	// Re-check under the lock: a concurrent caller may have generated the pair already.
+	if public.FileExists(dkimPriPath) && public.FileExists(dkimPubPath) {
+		return nil
+	}
+
+	dk, err := docker.NewDockerAPI()
+	if err != nil {
+		return fmt.Errorf("Failed to connect to Docker API: %v", err)
+	}
+	defer dk.Close()
+
+	var res *v2.ExecResult
+	res, err = dk.ExecCommandByName(ctx, consts.SERVICES.Rspamd, []string{"rspamadm", "dkim_keygen", "-s", selector, "-b", fmt.Sprintf("%d", keySize), "-d", domain, "-k", fmt.Sprintf("/var/lib/rspamd/dkim/%s/%s.private", domain, selector)}, "root")
+	if err != nil {
+		return fmt.Errorf("Failed to generate DKIM key pair: %v", err)
+	}
+
+	if res != nil {
+		if _, err = public.WriteFile(dkimPubPath, res.Output); err != nil {
+			return fmt.Errorf("Failed to write DKIM public key: %v", err)
+		}
+	}
+
+	// update dkim private key file permission to 0644
+	if err = os.Chmod(dkimPriPath, 0644); err != nil {
+		return fmt.Errorf("Failed to change DKIM private key permissions: %v", err)
+	}
+
+	return nil
+}
+
 func getDKIMRecordWithKeySize(domain, selector string, keySize int, validateImmediate bool) (record v1.DNSRecord, err error) {
 	// Create DKIM directory
 	dkimPath := public.AbsPath(filepath.Join(consts.RSPAMD_LIB_PATH, "dkim", domain))
@@ -547,30 +595,12 @@ func getDKIMRecordWithKeySize(domain, selector string, keySize int, validateImme
 
 	// Generate new keys if they don't exist
 	if !public.FileExists(dkimPriPath) || !public.FileExists(dkimPubPath) {
+		if err = ensureDKIMKeyPair(context.Background(), domain, selector, keySize); err != nil {
+			return
+		}
+
 		mutex.Lock()
 		defer mutex.Unlock()
-
-		var res *v2.ExecResult
-		res, err = dk.ExecCommandByName(context.Background(), consts.SERVICES.Rspamd, []string{"rspamadm", "dkim_keygen", "-s", selector, "-b", fmt.Sprintf("%d", keySize), "-d", domain, "-k", fmt.Sprintf("/var/lib/rspamd/dkim/%s/%s.private", domain, selector)}, "root")
-		if err != nil {
-			err = fmt.Errorf("Failed to generate DKIM key pair: %v", err)
-			return
-		}
-
-		if res != nil {
-			_, err = public.WriteFile(dkimPubPath, res.Output)
-			if err != nil {
-				err = fmt.Errorf("Failed to write DKIM public key: %v", err)
-				return
-			}
-		}
-
-		// update dkim private key file permission to 0644
-		err = os.Chmod(dkimPriPath, 0644)
-		if err != nil {
-			err = fmt.Errorf("Failed to change DKIM private key permissions: %v", err)
-			return
-		}
 
 		// Skip DKIM signing config for relay-mapped domains — relay provider signs
 		relayDomains, relayErr := GetRelayDomains(context.Background())
@@ -927,6 +957,7 @@ func RepairDKIMSigningConfig(ctx context.Context) error {
 			continue
 		}
 		// Regenerate missing DKIM key files
+		keysReady := true
 		for _, sel := range []struct {
 			name string
 			size int
@@ -934,9 +965,20 @@ func RepairDKIMSigningConfig(ctx context.Context) error {
 			keyPath := public.AbsPath(filepath.Join(consts.RSPAMD_LIB_PATH, "dkim", d.Domain, sel.name+".private"))
 			if !public.FileExists(keyPath) {
 				g.Log().Warningf(ctx, "DKIM key missing for %s/%s, regenerating", d.Domain, sel.name)
-				getDKIMRecordWithKeySize(d.Domain, sel.name, sel.size, false)
+				if genErr := ensureDKIMKeyPair(ctx, d.Domain, sel.name, sel.size); genErr != nil {
+					g.Log().Errorf(ctx, "Failed to regenerate DKIM key for %s/%s: %v", d.Domain, sel.name, genErr)
+					keysReady = false
+				}
 			}
 		}
+
+		// A signing block naming a key file that does not exist makes rspamd fail to sign for
+		// this domain, so leave the domain out entirely rather than emit a broken block.
+		if !keysReady {
+			g.Log().Warningf(ctx, "Excluding %s from DKIM signing config: key regeneration failed", d.Domain)
+			continue
+		}
+
 		// For each domain, generate the correct config block with both selectors
 		signConf := fmt.Sprintf(`
 #%s_DKIM_BEGIN


### PR DESCRIPTION
Fixes #372.

`RepairDKIMSigningConfig` called `getDKIMRecordWithKeySize` as a bare statement, so the `(v1.DNSRecord, error)` return was discarded. A failed regeneration was therefore silent, and the loop still appended a signing block naming a private key that does not exist — rspamd then fails to sign for that domain with no indication why.

That call also did much more than the repair path needs. On the keys-missing path `getDKIMRecordWithKeySize` rewrites `dkim_signing.conf` and restarts the rspamd container, while `RepairDKIMSigningConfig` overwrites the same file with the full rebuilt content and restarts rspamd itself at step 6. A host with N domains and missing keys — the clean-reinstall case in #117 — restarted rspamd up to 2N times inside the loop before the caller did the real work.

### Change

Extract `ensureDKIMKeyPair`, which touches key files only: create the directory, run `rspamadm dkim_keygen`, write the `.pub`, fix permissions. No signing-config write, no container restart — the caller owns both.

- `getDKIMRecordWithKeySize` calls it and keeps its existing behaviour, including the config write and restart.
- `RepairDKIMSigningConfig` calls it, logs a failure, and excludes that domain from the config rather than emitting a block that points at a missing key. The redundant restarts disappear because the caller already restarts once at the end.

The helper also re-checks for the key pair while holding the mutex. The existing check happens before the lock and generation then runs unconditionally, so two concurrent callers for the same domain and selector could both run `dkim_keygen`, the second overwriting the first key.

### Verification

`go build ./internal/service/domains/` and `gofmt -l` clean on this branch. Behaviour was also exercised on a local stack while adopting the surrounding commits downstream: creating a relay mapping emptied the generated `dkim_signing.conf` domain block, deleting it restored both selectors, and delivered mail carried two `DKIM-Signature` headers again.

Note `go build ./...` does not pass on `dev` for unrelated pre-existing reasons — `go.mod` omits `google.golang.org/grpc` although it is imported, and `run_dev.go` declares a second `func main()` in `package main`. Both are noted in #371.
