### PR TITLE
fix(stats): always report open and click rate per mail provider

### DIFF
--- a/core/internal/service/batch_mail/stat_service.go
+++ b/core/internal/service/batch_mail/stat_service.go
@@ -366,9 +366,15 @@ func (s *TaskStatService) getTaskMailProviders(taskId int64, domain string, star
 			provider["delivery_rate"] = public.Round(float64(delivered)/float64(sends)*100, 2)
 			provider["bounce_rate"] = public.Round(float64(result["bounced"].Int())/float64(sends)*100, 2)
 		}
+		// open_rate and click_rate are computed here rather than selected, so skipping them on a
+		// zero denominator drops the fields from the response entirely. A provider whose mail all
+		// bounced has delivered == 0 and still has to report rates.
 		if delivered > 0 {
 			provider["open_rate"] = public.Round(float64(result["opened"].Int())/float64(delivered)*100, 2)
 			provider["click_rate"] = public.Round(float64(result["clicked"].Int())/float64(delivered)*100, 2)
+		} else {
+			provider["open_rate"] = 0.0
+			provider["click_rate"] = 0.0
 		}
 		providers = append(providers, provider)
 	}


### PR DESCRIPTION
Fixes #373.

`open_rate` and `click_rate` are computed in Go rather than selected by the query — the field list is `mail_provider, sends, delivered, opened, clicked, bounced`. So when the `delivered > 0` guard does not fire, the keys are absent from the provider map entirely instead of reporting zero, and `/api/batch_mail/tracking/mail_provider` returns provider objects with those fields missing.

The trigger is a provider with `sends > 0` and `delivered == 0` — every message bounced — which is exactly the situation an operator is reading the dashboard to diagnose.

Before 1190a940 all four rates sat inside `if sends > 0`, so `open_rate` was always present as `opened / sends`. This restores that guarantee with the corrected denominator.

The same commit already added `else` branches setting zero at its two other call sites, `getTaskDashboard` in this file and `overviewDashboard` in `maillog_stat/overview.go`, so this brings `getTaskMailProviders` in line with them.

The `sends > 0` branch is deliberately left without an `else`: `sends` comes from `count(*)` with `GROUP BY mail_provider`, so it is always at least 1 and the branch is unreachable.

### Verification

`go build ./internal/service/batch_mail/` and `gofmt -l` clean on this branch.
